### PR TITLE
feat(rpc): give server getter and setter for spaceship data

### DIFF
--- a/lib/Data/Direction.cpp
+++ b/lib/Data/Direction.cpp
@@ -1,0 +1,20 @@
+#include "Direction.h"
+
+namespace cg {
+    Direction::Direction (Synchro::Direction::Reader reader)
+            : accelerate (reader.getAccelerate())
+            , decelerate (reader.getDecelerate())
+            , rotateLeft (reader.getRotateLeft())
+            , rotateRight (reader.getRotateRight())
+            {
+            }
+
+    void Direction::initialise (Synchro::Direction::Builder builder) const {
+        builder.setAccelerate (accelerate);
+        builder.setDecelerate (decelerate);
+        builder.setRotateLeft (rotateLeft);
+        builder.setRotateRight (rotateRight);
+    }
+}
+
+/* Copyright © 2022 Aaron Alef */

--- a/lib/Data/Direction.h
+++ b/lib/Data/Direction.h
@@ -1,12 +1,19 @@
 #ifndef CAPSTONE_DIRECTION_H
 #define CAPSTONE_DIRECTION_H
 
+#include "Server/generated/synchro.capnp.h"
+
 namespace cg {
     struct Direction {
         char accelerate: 2 = false;
         char decelerate: 2 = false;
         char rotateLeft: 2 = false;
         char rotateRight: 2 = false;
+
+        Direction() = default;
+        explicit Direction (Synchro::Direction::Reader reader);
+
+        void initialise (Synchro::Direction::Builder builder) const;
     };
 };
 

--- a/lib/Data/Spaceship.cpp
+++ b/lib/Data/Spaceship.cpp
@@ -11,6 +11,14 @@ namespace cg {
             {
             }
 
+    Spaceship::Spaceship (std::string username, vector2 position, vector2 velocity, float angle)
+            : username {std::move (username)}
+            , position {position}
+            , velocity {velocity}
+            , angle {angle}
+            {
+            }
+
     void Spaceship::initialise (Synchro::Spaceship::Builder builder) const {
         builder.setUsername (username);
 

--- a/lib/Data/Spaceship.cpp
+++ b/lib/Data/Spaceship.cpp
@@ -1,0 +1,29 @@
+#include "Spaceship.h"
+
+namespace cg {
+    Spaceship::Spaceship (Synchro::Spaceship::Reader reader)
+            : username {reader.getUsername()}
+            , position {reader.getPosition().getX(),
+                        reader.getPosition().getY()}
+            , velocity {reader.getVelocity().getX(),
+                        reader.getVelocity().getY()}
+            , angle {reader.getAngle()}
+            {
+            }
+
+    void Spaceship::initialise (Synchro::Spaceship::Builder builder) const {
+        builder.setUsername (username);
+
+        auto pos = builder.initPosition();
+        pos.setX (position[0]);
+        pos.setY (position[1]);
+
+        auto vel = builder.initVelocity();
+        vel.setX (velocity[0]);
+        vel.setY (velocity[1]);
+
+        builder.setAngle (angle);
+    }
+}
+
+/* Copyright © 2022 Aaron Alef */

--- a/lib/Data/Spaceship.h
+++ b/lib/Data/Spaceship.h
@@ -4,12 +4,18 @@
 #include <string>
 #include <array>
 
+#include "Server/generated/synchro.capnp.h"
+
 namespace cg {
     struct Spaceship {
         std::string username;
         std::array<float, 2> position = {0};
         std::array<float, 2> velocity = {0};
         float angle;
+
+        explicit Spaceship (Synchro::Spaceship::Reader reader);
+
+        void initialise (Synchro::Spaceship::Builder builder) const;
     };
 }
 

--- a/lib/Data/Spaceship.h
+++ b/lib/Data/Spaceship.h
@@ -7,13 +7,16 @@
 #include "Server/generated/synchro.capnp.h"
 
 namespace cg {
+    using vector2 = std::array <float, 2>;
+
     struct Spaceship {
         std::string username;
-        std::array<float, 2> position = {0};
-        std::array<float, 2> velocity = {0};
+        vector2 position = {0};
+        vector2 velocity = {0};
         float angle;
 
         explicit Spaceship (Synchro::Spaceship::Reader reader);
+        Spaceship (std::string username, vector2 position, vector2 velocity, float angle);
 
         void initialise (Synchro::Spaceship::Builder builder) const;
     };

--- a/lib/Server/Callback/ItemSink.cpp
+++ b/lib/Server/Callback/ItemSink.cpp
@@ -33,14 +33,10 @@ namespace cg {
     ::kj::Promise<void> ItemSinkImpl::sendItem (SendItemContext context) {
         try {
             auto direction = context.getParams ().getItem ().getDirection ();
-            callbacks.onSendItem ({
-                direction.getAccelerate (),
-                direction.getDecelerate (),
-                direction.getRotateLeft (),
-                direction.getRotateRight ()
-            });
+            callbacks.onSendItem (Direction (direction));
+
         } catch (std::bad_function_call & e) {
-//            KJ_DLOG (WARNING, "ItemSink::sendItem called without valid callback registered");
+            KJ_DLOG (WARNING, "ItemSink::sendItem called without valid callback registered");
         }
 
         return kj::READY_NOW;

--- a/lib/Server/Callback/ShipCallback.cpp
+++ b/lib/Server/Callback/ShipCallback.cpp
@@ -11,27 +11,47 @@ namespace cg {
     void ShipCallbackImpl::setOnSendSink (SendSinkCallbackHandle const & onSendSink) {
         this->onSendSink = onSendSink;
     }
+    void ShipCallbackImpl::setOnGetSpaceship (GetSpaceshipCallbackHandle const & onGetSpaceship) {
+        this->onGetSpaceship = onGetSpaceship;
+    }
+    void ShipCallbackImpl::setOnSetSpaceship (SetSpaceshipCallbackHandle const & onSetSpaceship) {
+        this->onSetSpaceship = onSetSpaceship;
+    }
 
     ::kj::Promise<void> ShipCallbackImpl::sendSink (SendSinkContext context) {
         auto spaceship = context.getParams().getSpaceship();
-        auto position = spaceship.getPosition();
-        auto velocity = spaceship.getVelocity();
         auto username = spaceship.getUsername();
-        auto angle    = spaceship.getAngle();
         log ("New Spaceship: " + std::string (username));
 
         try {
-            context.getResults().setSink (onSendSink ({
-                username, {
-                    position.getX(),
-                    position.getY()
-                }, {
-                    velocity.getX(),
-                    velocity.getY()
-                }, angle
-                }));
+            context.getResults().setSink (onSendSink (Spaceship (spaceship)));
         } catch (std::bad_function_call & e) {
             KJ_DLOG (WARNING, "ShipCallback::sendSink called without valid callback registered");
+        }
+
+        return kj::READY_NOW;
+    }
+
+    ::kj::Promise<void> ShipCallbackImpl::getSpaceship (GetSpaceshipContext context) {
+        try {
+            onGetSpaceship ()
+                .initialise (context.getResults().getSpaceship());
+
+        } catch (std::bad_function_call & e) {
+            KJ_DLOG (WARNING, "ShipCallback::getSpaceship called without valid callback registered");
+        }
+
+        return kj::READY_NOW;
+    }
+
+    ::kj::Promise<void> ShipCallbackImpl::setSpaceship (SetSpaceshipContext context) {
+        auto ship = context.getParams().getSpaceship();
+
+        try {
+            onSetSpaceship (Spaceship (ship));
+
+        } catch (std::bad_function_call & e) {
+            KJ_DLOG (WARNING, "ShipCallback::setSpaceship called without valid callback registered");
         }
 
         return kj::READY_NOW;

--- a/lib/Server/Callback/ShipCallback.cpp
+++ b/lib/Server/Callback/ShipCallback.cpp
@@ -21,7 +21,7 @@ namespace cg {
         log ("New Spaceship: " + std::string (username));
 
         try {
-            context.getResults().setShip (onSendSink ({
+            context.getResults().setSink (onSendSink ({
                 username, {
                     position.getX(),
                     position.getY()

--- a/lib/Server/Callback/ShipCallback.cpp
+++ b/lib/Server/Callback/ShipCallback.cpp
@@ -45,10 +45,10 @@ namespace cg {
     }
 
     ::kj::Promise<void> ShipCallbackImpl::setSpaceship (SetSpaceshipContext context) {
-        auto ship = context.getParams().getSpaceship();
+        Spaceship ship (context.getParams().getSpaceship());
 
         try {
-            onSetSpaceship (Spaceship (ship));
+            onSetSpaceship (ship);
 
         } catch (std::bad_function_call & e) {
             KJ_DLOG (WARNING, "ShipCallback::setSpaceship called without valid callback registered");

--- a/lib/Server/Callback/ShipCallback.h
+++ b/lib/Server/Callback/ShipCallback.h
@@ -22,11 +22,17 @@
 
 namespace cg {
     using SendSinkCallback       = std::function <kj::Own <cg::ItemSinkImpl> (Spaceship)>;
-    using SendSinkCallbackHandle = std::function <kj::Own <cg::ItemSinkImpl> (Spaceship)>;
+    using SendSinkCallbackHandle = SendSinkCallback;
+    using GetSpaceshipCallback       = std::function <Spaceship ()>;
+    using GetSpaceshipCallbackHandle = GetSpaceshipCallback;
+    using SetSpaceshipCallback       = std::function <void (Spaceship)>;
+    using SetSpaceshipCallbackHandle = SetSpaceshipCallback;
 
     class ShipCallbackImpl final: public Synchro::ShipCallback::Server {
     private:
         SendSinkCallback onSendSink;
+        GetSpaceshipCallback onGetSpaceship;
+        SetSpaceshipCallback onSetSpaceship;
 
         void log (std::string const & msg);
 
@@ -35,8 +41,12 @@ namespace cg {
         ~ShipCallbackImpl() = default;
 
         void setOnSendSink (SendSinkCallbackHandle const & onSendSink);
+        void setOnGetSpaceship (GetSpaceshipCallbackHandle const & onGetSpaceship);
+        void setOnSetSpaceship (SetSpaceshipCallbackHandle const & onSetSpaceship);
 
         ::kj::Promise<void> sendSink (SendSinkContext context) override;
+        ::kj::Promise<void> getSpaceship (GetSpaceshipContext context) override;
+        ::kj::Promise<void> setSpaceship (SetSpaceshipContext context) override;
     };
 } // cg
 

--- a/lib/Server/Server.cpp
+++ b/lib/Server/Server.cpp
@@ -164,7 +164,7 @@ namespace cg {
             vel.setY (sender.velocity[1]);
             ship.setAngle (sender.angle);
         }
-        sinks.emplace (sender.username, request.send().getShip());
+        sinks.emplace (sender.username, request.send().getSink());
     }
 
     void SynchroImpl::broadcastSpaceship (Spaceship const & sender) {

--- a/lib/Server/Server.cpp
+++ b/lib/Server/Server.cpp
@@ -100,7 +100,9 @@ namespace cg {
                 connections.at (sender).shipCallback.getSpaceshipRequest().send().then (
                         [&] (capnp::Response<Synchro::ShipCallback::GetSpaceshipResults> response) {
                     distributeSpaceship (Spaceship (response.getSpaceship()), receiver);
+                    sendItemCallback (sender, direction);
                 });
+                return;
             }
 
             KJ_REQUIRE (sinks.contains (sender));

--- a/lib/Server/Server.cpp
+++ b/lib/Server/Server.cpp
@@ -97,11 +97,11 @@ namespace cg {
             auto & sinks = pair.second.itemSinks;
 
             if (! sinks.contains (sender)) {
-                connections.at (sender).shipCallback.getSpaceshipRequest().send().then (
+                detach(connections.at (sender).shipCallback.getSpaceshipRequest().send().then (
                         [&] (capnp::Response<Synchro::ShipCallback::GetSpaceshipResults> response) {
                     distributeSpaceship (Spaceship (response.getSpaceship()), receiver);
                     sendItemCallback (sender, direction);
-                });
+                }));
                 return;
             }
 

--- a/lib/Server/Server.h
+++ b/lib/Server/Server.h
@@ -48,7 +48,7 @@ namespace cg {
         /// Seed used to initialise the game. Returned by `randomSeed`
         std::size_t const rng_seed;
 
-        void sendItemCallback (std::string sender, Direction direction);
+        void sendItemCallback (std::string const & sender, Direction direction);
         void doneCallback     (std::string username);
 
         void distributeSpaceship (Spaceship const & sender, std::string const & receiver);

--- a/lib/Server/synchro.capnp
+++ b/lib/Server/synchro.capnp
@@ -38,7 +38,8 @@ interface Synchro {
 
     interface ShipCallback {
         sendSink @0 (spaceship :Spaceship) -> (sink :ItemSink);
-        requestData @1 () -> (spaceship :Spaceship);
+        getSpaceship @1 () -> (spaceship :Spaceship);
+        setSpaceship @2 (spaceship :Spaceship) -> ();
     }
 
     ping @0 ();

--- a/lib/Server/synchro.capnp
+++ b/lib/Server/synchro.capnp
@@ -37,7 +37,8 @@ interface Synchro {
     }
 
     interface ShipCallback {
-        sendSink @0 (spaceship :Spaceship) -> (ship :ItemSink);
+        sendSink @0 (spaceship :Spaceship) -> (sink :ItemSink);
+        requestData @1 () -> (spaceship :Spaceship);
     }
 
     ping @0 ();

--- a/src/Spaceship/KeyboardSpaceship.cpp
+++ b/src/Spaceship/KeyboardSpaceship.cpp
@@ -15,22 +15,12 @@ namespace kt {
 
                 auto request = client.getMain <Synchro> ().joinRequest ();
                 request.initOther().setValue (kj::heap <cg::SynchroImpl> (1));
-                {
-                    auto ship = request.initSpaceship();
-                    ship.setUsername (USERNAME);
-                    auto pos = ship.initPosition();
-                    auto real_pos = getPhysicalPosition();
-                    pos.setX (real_pos.x);
-                    pos.setY (real_pos.y);
-                    auto vel = ship.initVelocity();
-                    auto real_vel = getPhysicalVelocity();
-                    vel.setX (real_vel.x);
-                    vel.setY (real_vel.y);
-                    ship.setAngle (getRotation());
-                }
+                getData().initialise (request.initSpaceship());
 
                 auto shipCB = kj::heap <cg::ShipCallbackImpl> ();
                 shipCB->setOnSendSink (world.onSendSink);
+                shipCB->setOnGetSpaceship (CLOSURE (this, & Spaceship::getData));
+                shipCB->setOnSetSpaceship (CLOSURE (this, & Spaceship::setData));
                 request.setShipCallback (kj::mv (shipCB));
 
                 return request.send().wait (client.getWaitScope()).getItemSink();

--- a/src/Spaceship/KeyboardSpaceship.cpp
+++ b/src/Spaceship/KeyboardSpaceship.cpp
@@ -81,11 +81,8 @@ namespace kt {
 
     void KeyboardSpaceship::update (UpdateState const & us) {
         auto request = sink.sendItemRequest ();
-        auto dir = request.initItem().initDirection();
-        dir.setAccelerate (queried.accelerate);
-        dir.setDecelerate (queried.decelerate);
-        dir.setRotateLeft (queried.rotateLeft);
-        dir.setRotateRight (queried.rotateRight);
+        queried.initialise (request.initItem().initDirection());
+
         auto promise = request.send();
         Spaceship::update (us);
         promise.wait (client.getWaitScope());

--- a/src/Spaceship/KeyboardSpaceship.h
+++ b/src/Spaceship/KeyboardSpaceship.h
@@ -11,6 +11,7 @@
 #include "Spaceship.h"
 
 #include "Server/Server.h"
+#include "Data/Spaceship.h"
 
 #define KEYBOARD_SPACESHIP_COLOR {0, 0, 255}
 

--- a/src/Spaceship/Spaceship.cpp
+++ b/src/Spaceship/Spaceship.cpp
@@ -144,6 +144,24 @@ namespace kt {
     void Spaceship::setPhysicalVelocity (b2Vec2 vel) {
         body->SetLinearVelocity (vel);
     }
+
+    cg::Spaceship Spaceship::getData () const {
+        return {
+            getName(), {
+                getPhysicalPosition().x,
+                getPhysicalPosition().y
+            }, {
+                getPhysicalVelocity().x,
+                getPhysicalVelocity().y
+            },
+            getRotation()
+        };
+    }
+    void Spaceship::setData (cg::Spaceship const & spaceship) {
+        setName (spaceship.username);
+        setPhysicalTransform ({spaceship.position[0], spaceship.position[1]}, spaceship.angle);
+        setPhysicalVelocity ({spaceship.velocity[0], spaceship.velocity[1]});
+    }
 }
 
 /* Copyright © 2022 Aaron Alef */

--- a/src/Spaceship/Spaceship.h
+++ b/src/Spaceship/Spaceship.h
@@ -12,6 +12,7 @@
 #include "src/Collision/CollisionEvent.h"
 #include "src/UI/Text.h"
 #include "Data/Direction.h"
+#include "Data/Spaceship.h"
 
 /// Relative spaceship size
 #define SPACESHIP_SCALE     2e-1
@@ -75,6 +76,9 @@ namespace kt {
 
         void setPhysicalTransform (b2Vec2 pos, float angle);
         void setPhysicalVelocity (b2Vec2 vel);
+
+        cg::Spaceship getData () const;
+        void setData (cg::Spaceship const & spaceship);
 
         /// Counter incrementing IDs. Reset on creating a new GameScene instance
         static std::size_t ship_counter;


### PR DESCRIPTION
NOTE: This PR gives the server control over spaceships. It will allow the server to request current pos/vel/angle and to set it.
Getting data is necessary to sync a spaceship up with the remote one of a newly joined client.
Setting data will soon be necessary to allow the server to sync data in more or less regular intervals.