### PR TITLE
feat(client): add identifiers to client-based interfaces

### DIFF
--- a/lib/Network/Backend.cpp
+++ b/lib/Network/Backend.cpp
@@ -50,9 +50,9 @@ namespace cg {
         });
         results.setRegistrar (kj::mv (registrar));
 
-        auto synchro = kj::heap <SynchroImpl>();
-        synchro->setOnConnect ([this] (Backend::Synchro::Client synchro, Backend::Registrar::Client registrar) {
-            return connectCallback (ID, synchro, registrar);
+        auto synchro = kj::heap <SynchroImpl>(ID);
+        synchro->setOnConnect ([this] (std::string const & id, Backend::Synchro::Client synchro, Backend::Registrar::Client registrar) {
+            return connectCallback (id, synchro, registrar);
         });
         results.setSynchro (kj::mv (synchro));
 
@@ -66,9 +66,9 @@ namespace cg {
 
         auto results = context.getResults();
         results.setId (ID);
-        auto local = kj::heap <SynchroImpl> ();
-        local->setOnConnect ([this] (Backend::Synchro::Client synchro, Backend::Registrar::Client registrar) {
-            return connectCallback (ID, synchro, registrar);
+        auto local = kj::heap <SynchroImpl> (ID);
+        local->setOnConnect ([this] (std::string const & id, Backend::Synchro::Client synchro, Backend::Registrar::Client registrar) {
+            return connectCallback (id, synchro, registrar);
         });
         results.setLocal (kj::mv (local));
 
@@ -76,9 +76,9 @@ namespace cg {
         KJ_REQUIRE (params.hasRemote());
         auto connectRequest = params.getRemote().connectRequest();
         connectRequest.setId (ID);
-        auto synchro = kj::heap <SynchroImpl> ();
-        synchro->setOnConnect ([this] (Backend::Synchro::Client synchro, Backend::Registrar::Client registrar) {
-            return connectCallback (ID, synchro, registrar);
+        auto synchro = kj::heap <SynchroImpl> (ID);
+        synchro->setOnConnect ([this] (std::string const & id, Backend::Synchro::Client synchro, Backend::Registrar::Client registrar) {
+            return connectCallback (id, synchro, registrar);
         });
         connectRequest.setSynchro (kj::mv (synchro));
         auto registrar = kj::heap <RegistrarImpl> ();

--- a/lib/Network/Backend.cpp
+++ b/lib/Network/Backend.cpp
@@ -216,16 +216,17 @@ namespace cg {
             std::cout << "| Clients total: " << clients.size() << std::endl;
             for (auto & client : clients) {
                 std::cout << "|-- Client '" << client.first << std::endl;
-                std::cout << "|-- Sinks total: " << client.second.sinks.size() << std::endl;
+                std::cout << "|---- Sinks total: " << client.second.sinks.size() << std::endl;
                 for (auto & sink : client.second.sinks) {
-                    std::cout << "|---- Ship name: " << sink.first << std::endl;
+                    std::cout << "|------ Ship name: " << sink.first << std::endl;
                 }
-                std::cout << "\n|-- Ships total: " << client.second.ships.size() << std::endl;
+                std::cout << "|\n|---- Ships total: " << client.second.ships.size() << std::endl;
                 for (auto & ship : client.second.ships) {
-                    std::cout << "|---- Ship name: " << ship.first << std::endl;
+                    std::cout << "|------ Ship name: " << ship.first << std::endl;
                 }
+                std::cout << '|' << std::endl;
             }
-            std::cout << "\n=========================\n" << std::endl;
+            std::cout << "=========================\n" << std::endl;
 
             // TODO: figure out where to get the remote ShipHandle from
 //            KJ_REQUIRE (ships.contains (username));

--- a/lib/Network/Backend.cpp
+++ b/lib/Network/Backend.cpp
@@ -228,6 +228,8 @@ namespace cg {
             }
             std::cout << "=========================\n" << std::endl;
 
+            return kj::READY_NOW;
+
             // TODO: figure out where to get the remote ShipHandle from
 //            KJ_REQUIRE (ships.contains (username));
 //            return ships.at (username).getShipRequest().send()

--- a/lib/Network/Backend.cpp
+++ b/lib/Network/Backend.cpp
@@ -135,8 +135,9 @@ namespace cg {
 
     kj::Promise <void> BackendImpl::broadcastSpaceship (Spaceship const & ship) {
         std::size_t i = 0;
+        log ("Broadcast ship to " + std::to_string (clients.size()) + " clients");
         for (auto & client : clients) {
-            log ("Broadcast ship " + ship.username + + " to client [" + std::to_string (++i) + "/" + std::to_string (clients.size()) + "]");
+            log ("Broadcast ship " + ship.username + " to client " + client.first);
             detach (distributeSpaceship (ship, client.second));
         }
         return kj::READY_NOW;
@@ -149,7 +150,7 @@ namespace cg {
             // Figure out which client is the owner of this spaceship (NOTE: std::find could not handle this properly)
             // TODO: Don't use a loop for this
             auto & ships = client.second.ships;
-            if (ships.contains (sender)) continue;
+            if (!ships.contains (sender)) continue;
 
             auto request = receiver.registrar.registerShipRequest ();
             ship.initialise (request.initShip ());
@@ -162,6 +163,8 @@ namespace cg {
                         receiver.sinks.insert_or_assign (sender, results.getSink ());
                     });
         }
+        KJ_FAIL_REQUIRE ("No handle for the given spaceship exists", ship.username);
+        return kj::READY_NOW;
     }
     kj::Promise <void> BackendImpl::doneCallback (std::string const & username) {
         log ("Disconnecting " + username);

--- a/lib/Network/Backend.cpp
+++ b/lib/Network/Backend.cpp
@@ -8,14 +8,13 @@ namespace cg {
     BackendImpl::Registrar::Registrar (Backend::Registrar::Client registrar): registrar {registrar} {}
 
     void BackendImpl::log (std::string const & msg) {
-        std::stringstream ss;
+        std::ostringstream ss;
         ss << "Backend @" << this << ": '" << msg << "'";
         KJ_DLOG (INFO, ss.str());
-//        std::cout << ss.str() << std::endl;
+        debug_stdout (ss.str());
     }
 
     ::kj::Promise <void> BackendImpl::ping (PingContext context) {
-        log ("Ping");
         return kj::READY_NOW;
     }
 

--- a/lib/Network/Backend.h
+++ b/lib/Network/Backend.h
@@ -35,46 +35,56 @@ namespace cg {
         /// Seed of random number generator of currently running game
         std::size_t const rng_seed;
 
-        struct Registrar {
+        /// Own identifier
+        std::string const ID;
+
+        /// Struct holding all kinds of information about things connected
+        struct Client {
+            /// Whether it is a local game client or a remote synchro backend (redundant; same as maybe <synchro>)
+            enum Type { LOCAL, REMOTE } type;
+
+            /// Thing used to update the client (e.g., new ship spawned)
             Backend::Registrar::Client registrar;
+
+            /// If the client is a remote backend use this to interact with it
+            kj::Maybe <Backend::Synchro::Client> synchro;
+
+            /// List of handles to all ships in possession registered by this client
+            std::unordered_map <std::string, Backend::ShipHandle::Client> ships;
+
+            /// List of all ship sinks this client needs to distribute incoming events to
             std::unordered_map <std::string, Backend::ShipSink::Client> sinks;
 
-            explicit Registrar (Backend::Registrar::Client registrar);
+            Client (Backend::Registrar::Client && registrar, kj::Maybe <Backend::Synchro::Client> && synchro, Type type = REMOTE);
+            explicit Client (Backend::Registrar::Client && registrar);
         };
-
-        /// List of all ships in possession
-        std::unordered_map <std::string, Backend::ShipHandle::Client> ships;
-
-        /// List of connected clients (the things that we want to keep up to date)
-        std::vector <Registrar> clients;
-
-        /// List of connected synchros (the things this backend should synchronise with)
-        std::vector <Backend::Synchro::Client> synchros;
+        /// List of all clients connected
+        std::unordered_map <std::string, Client> clients;
 
         /// Synchro callbacks
-        kj::Own <RegistrarImpl> connectCallback (Backend::Synchro::Client synchro, Backend::Registrar::Client remoteRegistrar);
+        kj::Own <RegistrarImpl> connectCallback (std::string const & id, Backend::Synchro::Client synchro, Backend::Registrar::Client remoteRegistrar);
 
         /// RegisterShip callback
-        kj::Own <ShipSinkImpl> registerShip (Spaceship const & ship, Backend::ShipHandle::Client);
-        kj::Promise <void> broadcastSpaceship (Spaceship const & ship);
-        kj::Promise <void> distributeSpaceship (Spaceship const & ship, Registrar & receiver);
+        kj::Own <ShipSinkImpl> registerShip    (Spaceship const & ship, std::string const & id, Backend::ShipHandle::Client);
+        kj::Promise <void> broadcastSpaceship  (Spaceship const & ship);
+        kj::Promise <void> distributeSpaceship (Spaceship const & ship, Client & receiver);
 
         /// ShipSink callbacks
-        kj::Promise <void> doneCallback (std::string const & username);
-        kj::Promise <void> sendItemCallback (std::string const & username, Direction const & direction);
-        kj::Promise <void> sendItemToClient (std::string const & username, Direction const & direction, Registrar& receiver);
+        kj::Promise <void> doneCallback     (std::string const & username);
+        kj::Promise <void> sendItemCallback (std::string const & username, Direction const & direction, std::string const & id);
+        kj::Promise <void> sendItemToClient (std::string const & username, Direction const & direction, Client & receiver);
 
         /// Log function of this implementation
         void log (std::string const & msg);
 
     public:
-        explicit BackendImpl (std::size_t seed);
+        explicit BackendImpl (std::size_t seed, std::string id);
 
         /** RPC function calls **/
-        ::kj::Promise <void> ping    (PingContext context) override;
-        ::kj::Promise <void> seed    (SeedContext context) override;
+        ::kj::Promise <void> ping    (PingContext    context) override;
+        ::kj::Promise <void> seed    (SeedContext    context) override;
         ::kj::Promise <void> connect (ConnectContext context) override;
-        ::kj::Promise <void> join    (JoinContext context) override;
+        ::kj::Promise <void> join    (JoinContext    context) override;
     };
 } // cg
 

--- a/lib/Network/Backend.h
+++ b/lib/Network/Backend.h
@@ -28,7 +28,6 @@
 
 namespace cg {
     using namespace std::string_literals;
-    using RegisterShipCallback = std::function <kj::Own <ShipSinkImpl> (Spaceship, Backend::ShipHandle::Client)>;
 
     class BackendImpl final: public Backend::Server {
     private:

--- a/lib/Network/Registrar/Registrar.cpp
+++ b/lib/Network/Registrar/Registrar.cpp
@@ -5,7 +5,7 @@ namespace cg {
         std::stringstream ss;
         ss << "Registrar @" << this << ": '" << msg << "'";
         KJ_DLOG (INFO, ss.str());
-//        std::cout << ss.str() << std::endl;
+        debug_stdout (ss.str());
     }
 
     ::kj::Promise <void> RegistrarImpl::registerShip (RegisterShipContext context) {

--- a/lib/Network/Registrar/Registrar.cpp
+++ b/lib/Network/Registrar/Registrar.cpp
@@ -9,13 +9,13 @@ namespace cg {
     }
 
     ::kj::Promise <void> RegistrarImpl::registerShip (RegisterShipContext context) {
-//        log ("Register ship requested");
+        log ("Register ship requested");
         auto params = context.getParams();
         KJ_REQUIRE (params.hasShip());
         KJ_REQUIRE (params.hasHandle());
 
         try {
-            context.getResults().setSink (onRegisterShip (Spaceship (params.getShip()), params.getHandle()));
+            context.getResults().setSink (onRegisterShip (Spaceship (params.getShip()), ID, params.getHandle()));
         } catch (std::bad_function_call & e) {
             KJ_DLOG (WARNING, "RegistrarImpl::registerShip called without valid callback registered");
         }

--- a/lib/Network/Registrar/Registrar.h
+++ b/lib/Network/Registrar/Registrar.h
@@ -6,9 +6,10 @@
 #include "Network/ShipHandle/ShipHandle.h"
 
 #include <functional>
+#include <string>
 
 namespace cg {
-    using RegisterShipCallback = std::function <kj::Own <ShipSinkImpl> (Spaceship, Backend::ShipHandle::Client)>;
+    using RegisterShipCallback = std::function <kj::Own <ShipSinkImpl> (Spaceship, std::string const &, Backend::ShipHandle::Client)>;
 
     class RegistrarImpl final: public Backend::Registrar::Server {
     private:
@@ -17,7 +18,11 @@ namespace cg {
 
         RegisterShipCallback onRegisterShip;
 
+        std::string const ID;
+
     public:
+        inline explicit RegistrarImpl (std::string id): ID {id} {}
+
         inline void setOnRegisterShip (RegisterShipCallback && callback) { onRegisterShip = callback; }
 
         ::kj::Promise <void> registerShip (RegisterShipContext context) override;

--- a/lib/Network/ShipHandle/ShipHandle.cpp
+++ b/lib/Network/ShipHandle/ShipHandle.cpp
@@ -5,7 +5,7 @@ namespace cg {
         std::stringstream ss;
         ss << "ShipHandle @" << this << ": '" << msg << "'";
         KJ_DLOG (INFO, ss.str ());
-//        std::cout << ss.str () << std::endl;
+        debug_stdout (ss.str());
     }
 
     ::kj::Promise <void> ShipHandleImpl::ping (PingContext context) {

--- a/lib/Network/ShipSink/ShipSink.cpp
+++ b/lib/Network/ShipSink/ShipSink.cpp
@@ -5,7 +5,7 @@ namespace cg {
         std::stringstream ss;
         ss << "ShipSink @" << this << ": '" << msg << "'";
         KJ_DLOG (INFO, ss.str ());
-//        std::cout << ss.str () << std::endl;
+        debug_stdout (ss.str());
     }
 
     ::kj::Promise <void> ShipSinkImpl::done (DoneContext context) {

--- a/lib/Network/Synchro/Synchro.cpp
+++ b/lib/Network/Synchro/Synchro.cpp
@@ -4,8 +4,8 @@ namespace cg {
     void SynchroImpl::log (std::string const & msg) {
         std::stringstream ss;
         ss << "Synchro @" << this << ": '" << msg << "'";
-                KJ_DLOG (INFO, ss.str());
-        std::cout << ss.str() << std::endl;
+        KJ_DLOG (INFO, ss.str());
+        debug_stdout (ss.str());
     }
 
     ::kj::Promise<void> SynchroImpl::connect (ConnectContext context) {

--- a/lib/Network/Synchro/Synchro.cpp
+++ b/lib/Network/Synchro/Synchro.cpp
@@ -1,8 +1,6 @@
 #include "Synchro.h"
 
 namespace cg {
-    SynchroImpl::SynchroImpl (std::string id): ID {id} {}
-
     void SynchroImpl::log (std::string const & msg) {
         std::stringstream ss;
         ss << "Synchro @" << this << ": '" << msg << "'";

--- a/lib/Network/Synchro/Synchro.cpp
+++ b/lib/Network/Synchro/Synchro.cpp
@@ -1,6 +1,8 @@
 #include "Synchro.h"
 
 namespace cg {
+    SynchroImpl::SynchroImpl (std::string id): ID {id} {}
+
     void SynchroImpl::log (std::string const & msg) {
         std::stringstream ss;
         ss << "Synchro @" << this << ": '" << msg << "'";
@@ -9,14 +11,17 @@ namespace cg {
     }
 
     ::kj::Promise<void> SynchroImpl::connect (ConnectContext context) {
-        log ("Connection request received");
         auto params = context.getParams();
+        KJ_REQUIRE (params.hasId());
+        log ("Connection request received from client " + std::string (params.getId()));
+
         KJ_REQUIRE (params.hasSynchro());
         KJ_REQUIRE (params.hasRegistrar());
         auto results = context.getResults();
 
         try {
-            results.setRegistrar (onConnect (params.getSynchro(), params.getRegistrar()));
+            results.setRegistrar (onConnect (params.getId(), params.getSynchro(), params.getRegistrar()));
+            results.setId (ID);
         } catch (std::bad_function_call & e) {
             KJ_DLOG (WARNING, "Synchro::connect called without valid callback registered");
         }

--- a/lib/Network/Synchro/Synchro.h
+++ b/lib/Network/Synchro/Synchro.h
@@ -9,7 +9,7 @@
 
 namespace cg {
     class RegistrarImpl;
-    using ConnectCallback = std::function <kj::Own <RegistrarImpl> (Backend::Synchro::Client, Backend::Registrar::Client)>;
+    using ConnectCallback = std::function <kj::Own <RegistrarImpl> (std::string const &, Backend::Synchro::Client, Backend::Registrar::Client)>;
 
     class SynchroImpl final: public Backend::Synchro::Server {
     private:
@@ -18,7 +18,11 @@ namespace cg {
 
         ConnectCallback onConnect;
 
+        std::string const ID;
+
     public:
+        explicit SynchroImpl (std::string id);
+
         inline void setOnConnect (ConnectCallback && callback) { onConnect = callback; }
 
         ::kj::Promise <void> connect (ConnectContext context) override;

--- a/lib/Network/Synchro/Synchro.h
+++ b/lib/Network/Synchro/Synchro.h
@@ -21,7 +21,7 @@ namespace cg {
         std::string const ID;
 
     public:
-        explicit SynchroImpl (std::string id);
+        inline explicit SynchroImpl (std::string id): ID {id} {}
 
         inline void setOnConnect (ConnectCallback && callback) { onConnect = callback; }
 

--- a/lib/Network/config.h
+++ b/lib/Network/config.h
@@ -5,6 +5,7 @@
 
 #include <kj/debug.h>
 #include <kj/memory.h>
+#include <kj/common.h>
 #include <capnp/ez-rpc.h>
 #include <capnp/message.h>
 

--- a/lib/Network/config.h
+++ b/lib/Network/config.h
@@ -8,6 +8,8 @@
 #include <capnp/ez-rpc.h>
 #include <capnp/message.h>
 
+#include "helper.h"
+
 #include <string>
 #include <iostream>
 #include <sstream>

--- a/lib/Network/synchro.capnp
+++ b/lib/Network/synchro.capnp
@@ -44,7 +44,7 @@ interface Backend {
     }
 
     interface Synchro {
-        connect @0 (synchro :Synchro, registrar :Registrar) -> (registrar :Registrar);
+        connect @0 (id :Text, synchro :Synchro, registrar :Registrar) -> (id :Text, registrar :Registrar);
     }
 
     ping @0 ();
@@ -53,9 +53,9 @@ interface Backend {
     seed @1 () -> (seed :UInt64);
     # Request RNG seed server is running for
 
-    connect @2 (registrar :Registrar) -> (registrar :Registrar, synchro :Synchro);
+    connect @2 (id :Text, registrar :Registrar) -> (id :Text, registrar :Registrar, synchro :Synchro);
     # Subscribe to Backend, get a local synchro instance
 
-    join @3 (remote :Synchro) -> (local :Synchro);
+    join @3 (id :Text, remote :Synchro) -> (id :Text, local :Synchro);
     # Tell a remote backend of our local synchro
 }

--- a/lib/helper.h
+++ b/lib/helper.h
@@ -1,7 +1,15 @@
 #ifndef CAPSTONE_HELPER_H
 #define CAPSTONE_HELPER_H
 
+#include <iostream>
+
 #define ONCE(expr) static bool __once__ = [this]() { ((expr)); return true; }()
+
+inline void debug_stdout (std::string const & message) {
+#ifdef DEBUG
+    std::cout << message << std::endl;
+#endif
+}
 
 #endif //CAPSTONE_HELPER_H
 

--- a/src/Backend/Backend.cpp
+++ b/src/Backend/Backend.cpp
@@ -18,7 +18,7 @@ namespace kt {
     void Backend::serve () {
         for (int i = 0; i < 100; i++) {
             try {
-                auto server = capnp::EzRpcServer (kj::heap <cg::BackendImpl> (seed), address);
+                auto server = capnp::EzRpcServer (kj::heap <cg::BackendImpl> (seed, USERNAME), address);
                 port = server.getPort ().wait (server.getWaitScope ());
                 logs::messageln ("Backend starts serving now");
 

--- a/src/Scene/GameScene.cpp
+++ b/src/Scene/GameScene.cpp
@@ -70,8 +70,8 @@ namespace kt {
     }
 
     kj::Own <cg::RegistrarImpl> GameScene::getRegistrarImpl () {
-        auto registrar = kj::heap <cg::RegistrarImpl> ();
-        registrar->setOnRegisterShip ([this] (cg::Spaceship const & data, ::Backend::ShipHandle::Client handle) -> kj::Own <cg::ShipSinkImpl> {
+        auto registrar = kj::heap <cg::RegistrarImpl> (USERNAME);
+        registrar->setOnRegisterShip ([this] (cg::Spaceship const & data, std::string const & id, ::Backend::ShipHandle::Client handle) -> kj::Own <cg::ShipSinkImpl> {
             try {
                 spWorld world = safeSpCast<World> (getFirstChild ());
 

--- a/src/Scene/GameScene.cpp
+++ b/src/Scene/GameScene.cpp
@@ -15,6 +15,7 @@ namespace kt {
             , waitscope {client.getWaitScope()}
             , handle {[this] () {
                 auto request = client.getMain <::Backend>().connectRequest();
+                request.setId (USERNAME);
                 request.setRegistrar (getRegistrarImpl());
                 auto result = request.send().wait (waitscope);
                 KJ_REQUIRE (result.hasSynchro());
@@ -167,6 +168,7 @@ namespace kt {
         auto [iterator, success] = remoteClients.emplace (ip, kj::heap <capnp::EzRpcClient> (ip, port));
         auto & remote = * iterator->second;
         auto request = remote.getMain <::Backend>().joinRequest();
+        request.setId (USERNAME);
         request.setRemote (handle.synchro);
         request.send().wait (remote.getWaitScope());
     }

--- a/test/src/Backend.cpp
+++ b/test/src/Backend.cpp
@@ -35,9 +35,12 @@ SCENARIO ("A backend returns the seed it was initialised with") {
         }
         WHEN ("I register as client") {
             auto registerClientRequest = main.connectRequest();
+            registerClientRequest.setId (USERNAME);
 
-            auto registrar = kj::heap <cg::RegistrarImpl> ();
-            registrar->setOnRegisterShip ([] (cg::Spaceship const & ship, Backend::ShipHandle::Client handle) {
+            auto registrar = kj::heap <cg::RegistrarImpl> (USERNAME);
+            registrar->setOnRegisterShip ([] (cg::Spaceship const & ship, std::string const & id, Backend::ShipHandle::Client handle) {
+                CHECK (id == USERNAME);
+
                 CHECK (ship.health == HEALTH_VALUE);
 
                 auto sink = kj::heap <cg::ShipSinkImpl> ();
@@ -58,6 +61,7 @@ SCENARIO ("A backend returns the seed it was initialised with") {
 
                 REQUIRE (registerClientResult.hasSynchro());
                 auto synchro = registerClientResult.getSynchro();
+                // TODO: test connection to synchro
 
                 REQUIRE (registerClientResult.hasRegistrar());
                 auto registrar = registerClientResult.getRegistrar();


### PR DESCRIPTION
This includes a need to transmit the own ID as parameter and likewise return the own ID as result.
Having unique identifiers for clients allows attributing each ship to the client that originally added it, hence resolving otherwise possible recursive ship registration chains and potentially disallowing controlling remote non-owned ships in the future.